### PR TITLE
Changed Season's Guard to third level

### DIFF
--- a/Spells and Psionics/Kiaric's Miscellaneous Spells (transcribed by decoratedboar)
+++ b/Spells and Psionics/Kiaric's Miscellaneous Spells (transcribed by decoratedboar)
@@ -264,7 +264,7 @@ SpellsList["season's guard"] = {
 	name : "Season's Guard",
 	source : ["HB", 0],
 	classes : ["druid", "paladin", "ranger"],
-	level : 2,
+	level : 3,
 	school : "Abjur",
 	time : "1 bns",
 	range : "Touch",


### PR DESCRIPTION
Protection from Poison is the same as one of the subeffects of an effect here and can't be cast as a bonus action, so without removing paladins' access to it, level 3 is a better fit for it.